### PR TITLE
Fix issue #29 - use r'' if any backslashes in a docstring

### DIFF
--- a/reports/affected_clusters.py
+++ b/reports/affected_clusters.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prints all clusters that are affected by selected rule.
+r"""Prints all clusters that are affected by selected rule.
 
 This script can be used to analyze data exported from `report` table by
 the following command typed into PSQL console:


### PR DESCRIPTION
Fix issue #29 - use r'' if any backslashes in a docstring