### PR TITLE
Script to retrieve list of clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,26 @@ python3 edn2json.py input.edn > output.json
 
 ------------------------------------------------------------------------------
 
+## Testing tools
+
+### `st.py` (Stage Tester)
+
+#### Description
+
+This script can be used to retrieve list of clusters from the external data
+pipeline through the standard REST API. Organization ID (a.k.a. account number)
+needs to be provided via CLI option, because list of clusters is filtered by
+organization.
+
+REST API on Stage environment is accessed through proxy. Proxy name should be
+provided via CLI together with user name and password used for basic auth.
+
+#### Generated documentation
+
+* https://redhatinsights.github.io/insights-results-aggregator-utils/packages/st.html
+
+------------------------------------------------------------------------------
+
 ## Database related tools
 
 ### `cleanup_old_results.py`

--- a/docs/packages/st.html
+++ b/docs/packages/st.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html;charset=utf-8">
+  <title>st.py</title>
+  <link rel="stylesheet" href="pycco.css">
+</head>
+<body>
+<div id='container'>
+  <div id="background"></div>
+  <div class='section'>
+    <div class='docs'><h1>st.py</h1></div>
+  </div>
+  <div class='clearall'>
+  <div class='section' id='section-0'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-0'>#</a>
+      </div>
+      
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span></span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-1'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-1'>#</a>
+      </div>
+      <p>Copyright © 2021 Pavel Tisnovsky</p>
+<p>Licensed under the Apache License, Version 2.0 (the &ldquo;License&rdquo;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at</p>
+<pre><code>http://www.apache.org/licenses/LICENSE-2.0
+</code></pre>
+<p>Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &ldquo;AS IS&rdquo; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Script to retrieve results from the external data pipeline through the standard REST API.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-2'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-2'>#</a>
+      </div>
+      <h2>Description</h2>
+<p>This script can be used to retrieve list of clusters from the external data
+pipeline through the standard REST API. Organization ID (a.k.a. account number)
+needs to be provided via CLI option, because list of clusters is filtered by
+organization.</p>
+<p>REST API on Stage environment is accessed through proxy. Proxy name should be
+provided via CLI together with user name and password used for basic auth.</p>
+<h2>Usage</h2>
+<pre><code>st.py [-h] -a ADDRESS -r PROXY -u USER -p PASSWORD -o ORGANIZATION [-l] [-v]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -a ADDRESS, --address ADDRESS
+                        Address of REST API for external data pipeline
+  -x PROXY, --proxy PROXY
+                        Proxy to be used to access REST API
+  -u USER, --user USER  User name for basic authentication
+  -p PASSWORD, --password PASSWORD
+                        Password for basic authentication
+  -o ORGANIZATION, --organization ORGANIZATION
+                        Organization ID/account number
+  -l, --cluster-list    Operation to retrieve list of clusters via REST API
+  -v, --verbose         Make messages verbose
+</code></pre>
+<h2>Generated documentation</h2>
+<p><a href="https://redhatinsights.github.io/insights-results-aggregator-utils/packages/st.html">https://redhatinsights.github.io/insights-results-aggregator-utils/packages/st.html</a></p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span class="kn">import</span> <span class="nn">requests</span>
+<span class="kn">import</span> <span class="nn">json</span>
+
+<span class="kn">from</span> <span class="nn">argparse</span> <span class="kn">import</span> <span class="n">ArgumentParser</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-3'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-3'>#</a>
+      </div>
+      <p>Retrieve all CLI arguments.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span class="k">def</span> <span class="nf">cli_arguments</span><span class="p">():</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-4'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-4'>#</a>
+      </div>
+      <p>First of all, we need to specify all command line flags that are
+recognized by this tool.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">parser</span> <span class="o">=</span> <span class="n">ArgumentParser</span><span class="p">()</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-5'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-5'>#</a>
+      </div>
+      <p>All supported command line arguments and flags</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-a&quot;</span><span class="p">,</span> <span class="s2">&quot;--address&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;address&quot;</span><span class="p">,</span> <span class="n">required</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Address of REST API for external data pipeline&quot;</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-x&quot;</span><span class="p">,</span> <span class="s2">&quot;--proxy&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;proxy&quot;</span><span class="p">,</span> <span class="n">required</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Proxy to be used to access REST API&quot;</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-u&quot;</span><span class="p">,</span> <span class="s2">&quot;--user&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">,</span> <span class="n">required</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;User name for basic authentication&quot;</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-p&quot;</span><span class="p">,</span> <span class="s2">&quot;--password&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;password&quot;</span><span class="p">,</span> <span class="n">required</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Password for basic authentication&quot;</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-o&quot;</span><span class="p">,</span> <span class="s2">&quot;--organization&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;organization&quot;</span><span class="p">,</span> <span class="n">required</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Organization ID/account number&quot;</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-l&quot;</span><span class="p">,</span> <span class="s2">&quot;--cluster-list&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;cluster_list&quot;</span><span class="p">,</span> <span class="n">action</span><span class="o">=</span><span class="s2">&quot;store_true&quot;</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Operation to retrieve list of clusters via REST API&quot;</span><span class="p">,</span>
+                        <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">)</span>
+
+    <span class="n">parser</span><span class="o">.</span><span class="n">add_argument</span><span class="p">(</span><span class="s2">&quot;-v&quot;</span><span class="p">,</span> <span class="s2">&quot;--verbose&quot;</span><span class="p">,</span> <span class="n">dest</span><span class="o">=</span><span class="s2">&quot;verbose&quot;</span><span class="p">,</span> <span class="n">action</span><span class="o">=</span><span class="s2">&quot;store_true&quot;</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+                        <span class="n">help</span><span class="o">=</span><span class="s2">&quot;Make messages verbose&quot;</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-6'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-6'>#</a>
+      </div>
+      <p>Now it is time to parse flags, check the actual content of command line
+and fill in the object named <code>args</code>.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="k">return</span> <span class="n">parser</span><span class="o">.</span><span class="n">parse_args</span><span class="p">()</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-7'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-7'>#</a>
+      </div>
+      <p>Entry point to this script.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span class="k">def</span> <span class="nf">main</span><span class="p">():</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-8'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-8'>#</a>
+      </div>
+      <p>Parse and process and command line arguments.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">args</span> <span class="o">=</span> <span class="n">cli_arguments</span><span class="p">()</span>
+    <span class="n">verbose</span> <span class="o">=</span> <span class="n">args</span><span class="o">.</span><span class="n">verbose</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-9'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-9'>#</a>
+      </div>
+      <p>setup proxy or proxies</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">proxies</span> <span class="o">=</span> <span class="p">{</span>
+       <span class="s1">&#39;https&#39;</span><span class="p">:</span> <span class="n">args</span><span class="o">.</span><span class="n">proxy</span>
+    <span class="p">}</span>
+
+    <span class="k">if</span> <span class="n">verbose</span><span class="p">:</span>
+        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Proxy settings:&quot;</span><span class="p">,</span> <span class="n">proxies</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-10'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-10'>#</a>
+      </div>
+      <p>tuple with items needed to be filled for basic authentication</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">auth</span> <span class="o">=</span> <span class="p">(</span><span class="n">args</span><span class="o">.</span><span class="n">user</span><span class="p">,</span> <span class="n">args</span><span class="o">.</span><span class="n">password</span><span class="p">)</span>
+
+    <span class="k">if</span> <span class="n">verbose</span><span class="p">:</span>
+        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Auth settings:&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="p">)</span>
+
+    <span class="k">if</span> <span class="n">args</span><span class="o">.</span><span class="n">cluster_list</span><span class="p">:</span>
+        <span class="n">retrieve_cluster_list</span><span class="p">(</span><span class="n">args</span><span class="o">.</span><span class="n">organization</span><span class="p">,</span> <span class="n">args</span><span class="o">.</span><span class="n">address</span><span class="p">,</span> <span class="n">proxies</span><span class="p">,</span> <span class="n">auth</span><span class="p">,</span> <span class="n">verbose</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-11'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-11'>#</a>
+      </div>
+      <p>Retrieve list of clusters from the external data pipeline REST API endpoint.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span class="k">def</span> <span class="nf">retrieve_cluster_list</span><span class="p">(</span><span class="n">organization</span><span class="p">,</span> <span class="n">address</span><span class="p">,</span> <span class="n">proxies</span><span class="p">,</span> <span class="n">auth</span><span class="p">,</span> <span class="n">verbose</span><span class="p">):</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-12'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-12'>#</a>
+      </div>
+      <p>construct URL to get list of clusters for given organization ID/account number</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">url</span> <span class="o">=</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">/v1/organizations/</span><span class="si">{}</span><span class="s1">/clusters&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">address</span><span class="p">,</span> <span class="n">organization</span><span class="p">)</span>
+
+    <span class="k">if</span> <span class="n">verbose</span><span class="p">:</span>
+        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;URL to access:&quot;</span><span class="p">,</span> <span class="n">url</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-13'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-13'>#</a>
+      </div>
+      <p>send request to REST API</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">response</span> <span class="o">=</span> <span class="n">requests</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">proxies</span><span class="o">=</span><span class="n">proxies</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="n">auth</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-14'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-14'>#</a>
+      </div>
+      <p>elementary check for response content</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="k">assert</span> <span class="n">response</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">,</span> <span class="s2">&quot;Proper response expected&quot;</span>
+    <span class="k">assert</span> <span class="n">response</span><span class="o">.</span><span class="n">status_code</span> <span class="o">==</span> <span class="mi">200</span><span class="p">,</span> <span class="s2">&quot;Unexpected HTTP code returned: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">response</span><span class="o">.</span><span class="n">status_code</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-15'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-15'>#</a>
+      </div>
+      <p>response should be in JSON format, time to parse it</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">payload</span> <span class="o">=</span> <span class="n">response</span><span class="o">.</span><span class="n">json</span><span class="p">()</span>
+    <span class="k">assert</span> <span class="n">payload</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">,</span> <span class="s2">&quot;JSON response expected&quot;</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-16'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-16'>#</a>
+      </div>
+      <p>check the payload content</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="k">assert</span> <span class="s2">&quot;status&quot;</span> <span class="ow">in</span> <span class="n">payload</span><span class="p">,</span> <span class="s2">&quot;&#39;status&#39; field needs to be present in the payload&quot;</span>
+    <span class="k">assert</span> <span class="s2">&quot;clusters&quot;</span> <span class="ow">in</span> <span class="n">payload</span><span class="p">,</span> <span class="s2">&quot;&#39;clusters&#39; field needs to be present in the payload&quot;</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-17'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-17'>#</a>
+      </div>
+      <p>print list of clusters to standard output</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre>    <span class="n">clusters</span> <span class="o">=</span> <span class="nb">sorted</span><span class="p">(</span><span class="n">payload</span><span class="p">[</span><span class="s2">&quot;clusters&quot;</span><span class="p">])</span>
+    <span class="k">for</span> <span class="n">cluster</span> <span class="ow">in</span> <span class="n">clusters</span><span class="p">:</span>
+        <span class="nb">print</span><span class="p">(</span><span class="n">cluster</span><span class="p">)</span></pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+  <div class='section' id='section-18'>
+    <div class='docs'>
+      <div class='octowrap'>
+        <a class='octothorpe' href='#section-18'>#</a>
+      </div>
+      <p>If this script is started from command line, run the <code>main</code> function which is
+entry point to the processing.</p>
+    </div>
+    <div class='code'>
+      <div class="highlight"><pre><span class="k">if</span> <span class="vm">__name__</span> <span class="o">==</span> <span class="s2">&quot;__main__&quot;</span><span class="p">:</span>
+    <span class="n">main</span><span class="p">()</span>
+
+</pre></div>
+    </div>
+  </div>
+  <div class='clearall'></div>
+</div>
+</body>

--- a/stage_tester/st.py
+++ b/stage_tester/st.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright © 2021 Pavel Tisnovsky
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to retrieve results from the external data pipeline through the standard REST API.
+
+Description
+-----
+
+Usage
+-----
+
+
+
+Generated documentation
+-----
+<https://redhatinsights.github.io/insights-results-aggregator-utils/packages/st.html>
+"""
+
+def main():
+    """Entry point to this script."""
+
+
+# If this script is started from command line, run the `main` function which is
+# entry point to the processing.
+if __name__ == "__main__":
+    main()

--- a/stage_tester/st.py
+++ b/stage_tester/st.py
@@ -100,6 +100,53 @@ def main():
     args = cli_arguments()
     verbose = args.verbose
 
+    # setup proxy or proxies
+    proxies = {
+       'https': args.proxy
+    }
+
+    if verbose:
+        print("Proxy settings:", proxies)
+
+    # tuple with items needed to be filled for basic authentication
+    auth = (args.user, args.password)
+
+    if verbose:
+        print("Auth settings:", auth)
+
+    if args.cluster_list:
+        retrieve_cluster_list(args.organization, args.address, proxies, auth, verbose)
+
+
+def retrieve_cluster_list(organization, address, proxies, auth, verbose):
+    """Retrieve list of clusters from the external data pipeline REST API endpoint."""
+    # construct URL to get list of clusters for given organization ID/account number
+    url = '{}/v1/organizations/{}/clusters'.format(address, organization)
+
+    if verbose:
+        print("URL to access:", url)
+
+    # send request to REST API
+    response = requests.get(url, proxies=proxies, auth=auth)
+
+    # elementary check for response content
+    assert response is not None, "Proper response expected"
+    assert response.status_code == 200, "Unexpected HTTP code returned: {}".format(
+            response.status_code)
+
+    # response should be in JSON format, time to parse it
+    payload = response.json()
+    assert payload is not None, "JSON response expected"
+
+    # check the payload content
+    assert "status" in payload, "'status' field needs to be present in the payload"
+    assert "clusters" in payload, "'clusters' field needs to be present in the payload"
+
+    # print list of clusters to standard output
+    clusters = sorted(payload["clusters"])
+    for cluster in clusters:
+        print(cluster)
+
 
 # If this script is started from command line, run the `main` function which is
 # entry point to the processing.

--- a/stage_tester/st.py
+++ b/stage_tester/st.py
@@ -19,10 +19,34 @@
 Description
 -----
 
+This script can be used to retrieve list of clusters from the external data
+pipeline through the standard REST API. Organization ID (a.k.a. account number)
+needs to be provided via CLI option, because list of clusters is filtered by
+organization.
+
+REST API on Stage environment is accessed through proxy. Proxy name should be
+provided via CLI together with user name and password used for basic auth.
+
 Usage
 -----
 
+```
+st.py [-h] -a ADDRESS -r PROXY -u USER -p PASSWORD -o ORGANIZATION [-l] [-v]
 
+optional arguments:
+  -h, --help            show this help message and exit
+  -a ADDRESS, --address ADDRESS
+                        Address of REST API for external data pipeline
+  -x PROXY, --proxy PROXY
+                        Proxy to be used to access REST API
+  -u USER, --user USER  User name for basic authentication
+  -p PASSWORD, --password PASSWORD
+                        Password for basic authentication
+  -o ORGANIZATION, --organization ORGANIZATION
+                        Organization ID/account number
+  -l, --cluster-list    Operation to retrieve list of clusters via REST API
+  -v, --verbose         Make messages verbose
+```
 
 Generated documentation
 -----

--- a/stage_tester/st.py
+++ b/stage_tester/st.py
@@ -53,8 +53,52 @@ Generated documentation
 <https://redhatinsights.github.io/insights-results-aggregator-utils/packages/st.html>
 """
 
+
+import requests
+import json
+
+from argparse import ArgumentParser
+
+
+def cli_arguments():
+    """Retrieve all CLI arguments."""
+    # First of all, we need to specify all command line flags that are
+    # recognized by this tool.
+    parser = ArgumentParser()
+
+    # All supported command line arguments and flags
+    parser.add_argument("-a", "--address", dest="address", required=True,
+                        help="Address of REST API for external data pipeline")
+
+    parser.add_argument("-x", "--proxy", dest="proxy", required=True,
+                        help="Proxy to be used to access REST API")
+
+    parser.add_argument("-u", "--user", dest="user", required=True,
+                        help="User name for basic authentication")
+
+    parser.add_argument("-p", "--password", dest="password", required=True,
+                        help="Password for basic authentication")
+
+    parser.add_argument("-o", "--organization", dest="organization", required=True,
+                        help="Organization ID/account number")
+
+    parser.add_argument("-l", "--cluster-list", dest="cluster_list", action="store_true",
+                        help="Operation to retrieve list of clusters via REST API",
+                        default=None)
+
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=None,
+                        help="Make messages verbose")
+
+    # Now it is time to parse flags, check the actual content of command line
+    # and fill in the object named `args`.
+    return parser.parse_args()
+
+
 def main():
     """Entry point to this script."""
+    # Parse and process and command line arguments.
+    args = cli_arguments()
+    verbose = args.verbose
 
 
 # If this script is started from command line, run the `main` function which is


### PR DESCRIPTION
# Description

Script to retrieve list of clusters

Description
-----

This script can be used to retrieve list of clusters from the external data
pipeline through the standard REST API. Organization ID (a.k.a. account number)
needs to be provided via CLI option, because list of clusters is filtered by
organization.

REST API on Stage environment is accessed through proxy. Proxy name should be
provided via CLI together with user name and password used for basic auth.

Usage
-----

```
st.py [-h] -a ADDRESS -r PROXY -u USER -p PASSWORD -o ORGANIZATION [-l] [-v]

optional arguments:
  -h, --help            show this help message and exit
  -a ADDRESS, --address ADDRESS
                        Address of REST API for external data pipeline
  -x PROXY, --proxy PROXY
                        Proxy to be used to access REST API
  -u USER, --user USER  User name for basic authentication
  -p PASSWORD, --password PASSWORD
                        Password for basic authentication
  -o ORGANIZATION, --organization ORGANIZATION
                        Organization ID/account number
  -l, --cluster-list    Operation to retrieve list of clusters via REST API
  -v, --verbose         Make messages verbose
```