### PR TITLE
Fix cluster writing in CSV

### DIFF
--- a/s3/download_prod_data/main.go
+++ b/s3/download_prod_data/main.go
@@ -43,7 +43,8 @@ func main() {
 		for j := range tarBalls {
 			err = downloadTarball(s3client, config.s3config, tarBalls[j])
 			checkError(err)
-			clusterWithoutSuperFolder := strings.Split(clusters[i], "/")[1]
+			splittedClusters := strings.Split(clusters[i], "/")
+			clusterWithoutSuperFolder := splittedClusters[len(splittedClusters)-2]
 			err = writeRow(w, clusterWithoutSuperFolder, tarBalls[j])
 			checkError(err)
 		}


### PR DESCRIPTION
# Description

Depending on the S3 bucket format, it would write the correct cluster UUID or not. This is because one of the buckets we are using has the clusters near the root level and the other uses some prefixes. 

Now I'm getting the cluster UUID from back to front instead of front to back. With these changes it won't fail as both buckets  use the same format for the last paths (CLUSTER/DATE/HOUR/TARBALL). 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
