### PR TITLE
[CCXDEV-14419] Removing CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# CCX Processing team members are the default owners of the repository
-* @tisnik @Bee-lee @JoseLSegura @matysek @epapbak @JiriPapousek @Jakub007d


### PR DESCRIPTION
Removing the CODEOWNERS file as a follow up after the discussion with team. https://issues.redhat.com/browse/CCXDEV-14419